### PR TITLE
Update ListFutureBorrowingsCommand

### DIFF
--- a/src/main/java/seedu/duke/commands/ListFutureBorrowingsCommand.java
+++ b/src/main/java/seedu/duke/commands/ListFutureBorrowingsCommand.java
@@ -19,9 +19,8 @@ public class ListFutureBorrowingsCommand extends Command {
     }
 
     public void execute(ItemList itemList, Ui ui) {
-        ui.showMessages("Here is a list of future borrowings: ");
-
         if (name.isPresent()) {
+            ui.showMessages("Here is a list of future borrowings for " + name.get() + ": ");
             for (int i = 0; i < itemList.getSize(); i++) {
                 Item borrowedItem = itemList.getItem(i);
                 ArrayList<BorrowRecord> borrowRecords = borrowedItem.getBorrowRecords();
@@ -37,6 +36,7 @@ public class ListFutureBorrowingsCommand extends Command {
                 }
             }
         } else {
+            ui.showMessages("Here is a list of future borrowings: ");
             for (int i = 0; i < itemList.getSize(); i++) {
                 Item borrowedItem = itemList.getItem(i);
                 ArrayList<BorrowRecord> borrowRecords = borrowedItem.getBorrowRecords();

--- a/src/main/java/seedu/duke/parser/ListFutureBorrowingsParser.java
+++ b/src/main/java/seedu/duke/parser/ListFutureBorrowingsParser.java
@@ -7,28 +7,23 @@ import seedu.duke.exceptions.InvMgrException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static seedu.duke.parser.CliSyntax.PREFIX_NAME;
+import static seedu.duke.parser.CliSyntax.*;
 
 public class ListFutureBorrowingsParser implements Parser<ListFutureBorrowingsCommand> {
 
     public ListFutureBorrowingsCommand parse(String args) throws InvMgrException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+                ArgumentTokenizer.tokenize(args, PREFIX_BORROWER_NAME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_BORROWER_NAME) & !args.isEmpty()) {
             throw new InvMgrException(Messages.INVALID_SYNTAX);
         }
 
-        Optional<String> name = argMultimap.getValue(PREFIX_NAME);
+        Optional<String> name = argMultimap.getValue(PREFIX_BORROWER_NAME);
 
         return new ListFutureBorrowingsCommand(name);
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     * For SearchCommand, at least one of PREFIX_NAME, PREFIX_QUANTITY, and PREFIX_DESCRIPTION is needed.
-     */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }

--- a/src/main/java/seedu/duke/parser/ListFutureBorrowingsParser.java
+++ b/src/main/java/seedu/duke/parser/ListFutureBorrowingsParser.java
@@ -7,7 +7,7 @@ import seedu.duke.exceptions.InvMgrException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static seedu.duke.parser.CliSyntax.*;
+import static seedu.duke.parser.CliSyntax.PREFIX_BORROWER_NAME;
 
 public class ListFutureBorrowingsParser implements Parser<ListFutureBorrowingsCommand> {
 


### PR DESCRIPTION
cant use listfb just on its own without the borrower name and the
current syntax is listfb n/BORROWER_NAME and not listfb p/BORROWER_NAME
on the UG

Let's:
*Modify ListFutureBorrowingsParser to work without borrower name
*Modify ListFutureBorrowingsParser to distinguish between presence and
absence of borrower name